### PR TITLE
Enable nginx “Fancy Index”

### DIFF
--- a/debian/marquee/00-nginx-conf
+++ b/debian/marquee/00-nginx-conf
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 apt install nginx
+apt install libnginx-mod-http-fancyindex
 
 rm -f /etc/nginx/sites-enabled/*
 

--- a/debian/marquee/nginx/conf/whatwg.conf
+++ b/debian/marquee/nginx/conf/whatwg.conf
@@ -25,9 +25,8 @@ gzip_types text/plain text/css application/json text/xml application/xml image/s
 
 include whatwg-headers.conf;
 
-autoindex on;
-autoindex_localtime off;
-autoindex_exact_size off;
+fancyindex on;
+fancyindex_exact_size off;
 
 include mime.types; # prevents adding types from clobbering all other defaults
 types {

--- a/debian/marquee/nginx/sites/images.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/images.whatwg.org.conf
@@ -8,8 +8,6 @@ server {
     include /etc/nginx/whatwg.conf;
 
     location / {
-        fancyindex on;
-        fancyindex_exact_size off;
         default_type image/png;
     }
 }

--- a/debian/marquee/nginx/sites/images.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/images.whatwg.org.conf
@@ -8,9 +8,8 @@ server {
     include /etc/nginx/whatwg.conf;
 
     location / {
-        autoindex on;
-        autoindex_localtime off;
-        autoindex_exact_size off;
+        fancyindex on;
+        fancyindex_exact_size off;
         default_type image/png;
     }
 }

--- a/debian/marquee/nginx/sites/n.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/n.whatwg.org.conf
@@ -8,9 +8,8 @@ server {
     include /etc/nginx/whatwg.conf;
 
     location / {
-        autoindex on;
-        autoindex_localtime off;
-        autoindex_exact_size off;
+        fancyindex on;
+        fancyindex_exact_size off;
         default_type text/plain;
     }
 

--- a/debian/marquee/nginx/sites/n.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/n.whatwg.org.conf
@@ -8,8 +8,6 @@ server {
     include /etc/nginx/whatwg.conf;
 
     location / {
-        fancyindex on;
-        fancyindex_exact_size off;
         default_type text/plain;
     }
 

--- a/debian/marquee/nginx/sites/resources.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/resources.whatwg.org.conf
@@ -6,10 +6,4 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/resources.whatwg.org/privkey.pem;
 
     include /etc/nginx/whatwg.conf;
-
-    location / {
-        autoindex on;
-        autoindex_localtime off;
-        autoindex_exact_size off;
-    }
 }


### PR DESCRIPTION
Among other things this change eliminates the problem with nginx showing
`../` in index/directory listings.

Addresses https://github.com/whatwg/whatwg.org/issues/84