### PR TITLE
Add Travis tests for cert validity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js: stable
+script:
+  - ./run-tests.sh

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+for t in tests/*; do
+    node "$t"
+done

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,11 @@
-#!/bin/sh -e
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
 
-for t in tests/*; do
-    node "$t"
+cd tests
+for test in *.js; do
+    echo "Running $test"
+    node "$test"
+    echo
 done

--- a/tests/certs.js
+++ b/tests/certs.js
@@ -1,0 +1,61 @@
+const fs = require('fs')
+const https = require('https')
+
+// Let's Encrypt should renew when 30 days remain, so if it's less than 25
+// something is wrong with certificate automation.
+const MAX_DAYS = 25
+
+const NOW = Date.now()
+const DAY_MS = 24 * 3600 * 1000
+
+const DOMAINS = new Set(fs.readFileSync('debian/marquee/DOMAINS')
+                        .toString().split(/[\s,]/).filter(d => d != ''))
+
+// TODO(foolip): when https://github.com/whatwg/misc-server/issues/7 is resolved
+// this can be removed.
+const EXTRA_DOMAINS = [
+  'blog.whatwg.org',
+  'build.whatwg.org',
+  'console.spec.whatwg.org',
+  'encoding.spec.whatwg.org',
+  'forums.whatwg.org',
+  'html.spec.whatwg.org',
+  //'lists.whatwg.org',
+  'mimesniff.spec.whatwg.org',
+  'storage.spec.whatwg.org',
+  'streams.spec.whatwg.org',
+  'url.spec.whatwg.org',
+  'whatwg.org', 'www.whatwg.org',
+  'wiki.whatwg.org',
+  'xhr.spec.whatwg.org',
+]
+for (const domain of EXTRA_DOMAINS) {
+  DOMAINS.add(domain)
+}
+
+function testCertificate(domain) {
+  return new Promise((resolve, reject) => {
+    https.request(`https://${domain}`, res => {
+      const cert = res.connection.getPeerCertificate()
+      const valid_to = Date.parse(cert.valid_to)
+      const days_left = (valid_to - NOW) / DAY_MS
+      if (days_left < MAX_DAYS)
+        resolve(`cert expires in less than ${MAX_DAYS} days: ${cert.valid_to}`)
+      resolve('OK')
+    }).end()
+  })
+}
+
+async function test() {
+  let ok = true
+  for (const domain of DOMAINS) {
+      const result = await testCertificate(domain)
+      console.log(domain, result)
+      if (result != 'OK')
+        ok = false
+  }
+  if (!ok)
+    process.exit(1)
+}
+
+test()

--- a/tests/certs.js
+++ b/tests/certs.js
@@ -1,4 +1,5 @@
-const fs = require('fs')
+'use strict'
+
 const https = require('https')
 
 // Let's Encrypt should renew when 30 days remain, so if it's less than 25

--- a/tests/certs.js
+++ b/tests/certs.js
@@ -82,7 +82,7 @@ async function test() {
     } catch (err) {
       status = err;
     }
-    if (status != 'OK')
+    if (status !== 'OK')
       ok = false
     console.log(domain, status)
   }

--- a/tests/certs.js
+++ b/tests/certs.js
@@ -5,55 +5,87 @@ const https = require('https')
 // something is wrong with certificate automation.
 const MAX_DAYS = 25
 
-const NOW = Date.now()
-const DAY_MS = 24 * 3600 * 1000
-
-const DOMAINS = new Set(fs.readFileSync('debian/marquee/DOMAINS')
-                        .toString().split(/[\s,]/).filter(d => d != ''))
-
-// TODO(foolip): when https://github.com/whatwg/misc-server/issues/7 is resolved
-// this can be removed.
-const EXTRA_DOMAINS = [
+const DOMAINS = [
   'blog.whatwg.org',
+  'books.idea.whatwg.org',
+  'books.spec.whatwg.org',
   'build.whatwg.org',
+  'c.whatwg.org',
+  'compat.spec.whatwg.org',
   'console.spec.whatwg.org',
+  'developer.whatwg.org',
+  'developers.whatwg.org',
+  'dom.spec.whatwg.org',
+  'domparsing.spec.whatwg.org',
   'encoding.spec.whatwg.org',
+  'fetch.spec.whatwg.org',
+  'figures.idea.whatwg.org',
+  'figures.spec.whatwg.org',
   'forums.whatwg.org',
+  'fullscreen.spec.whatwg.org',
+  'help.whatwg.org',
+  'html-differences.whatwg.org',
   'html.spec.whatwg.org',
-  //'lists.whatwg.org',
+  // 'lists.whatwg.org',
+  'idea.whatwg.org',
+  'images.whatwg.org',
+  'infra.spec.whatwg.org',
+  'javascript.spec.whatwg.org',
+  'mediasession.spec.whatwg.org',
   'mimesniff.spec.whatwg.org',
+  'n.whatwg.org',
+  'notifications.spec.whatwg.org',
+  'quirks.spec.whatwg.org',
+  'resources.whatwg.org',
+  'spec.whatwg.org',
+  'specs.whatwg.org',
   'storage.spec.whatwg.org',
   'streams.spec.whatwg.org',
+  'svn.whatwg.org',
   'url.spec.whatwg.org',
-  'whatwg.org', 'www.whatwg.org',
+  'validator.whatwg.org',
+  'webvtt.spec.whatwg.org',
+  'whatwg.org',
   'wiki.whatwg.org',
+  'www.whatwg.org',
   'xhr.spec.whatwg.org',
+  'xn--7ca.whatwg.org',
 ]
-for (const domain of EXTRA_DOMAINS) {
-  DOMAINS.add(domain)
-}
 
-function testCertificate(domain) {
+function getCertificate(domain) {
   return new Promise((resolve, reject) => {
-    https.request(`https://${domain}`, res => {
-      const cert = res.connection.getPeerCertificate()
-      const valid_to = Date.parse(cert.valid_to)
-      const days_left = (valid_to - NOW) / DAY_MS
-      if (days_left < MAX_DAYS)
-        resolve(`cert expires in less than ${MAX_DAYS} days: ${cert.valid_to}`)
-      resolve('OK')
-    }).end()
+    const req = https.request(`https://${domain}`, res => {
+      resolve(res.connection.getPeerCertificate())
+    })
+    req.on('error', err => reject(err))
+    req.end()
   })
 }
 
 async function test() {
+  const now = Date.now()
+
+  // start all the requests in parallel
+  const requests = DOMAINS.map(domain => [domain, getCertificate(domain)])
+
   let ok = true
-  for (const domain of DOMAINS) {
-      const result = await testCertificate(domain)
-      console.log(domain, result)
-      if (result != 'OK')
-        ok = false
+
+  for (const [domain, request] of requests) {
+    let status = 'OK'
+    try {
+      const cert = await request
+      const valid_to = Date.parse(cert.valid_to)
+      const days_left = (valid_to - now) / (24 * 3600 * 1000)
+      if (days_left < MAX_DAYS)
+        status = `cert expires in less than ${MAX_DAYS} days: ${cert.valid_to}`
+    } catch (err) {
+      status = err;
+    }
+    if (status != 'OK')
+      ok = false
+    console.log(domain, status)
   }
+
   if (!ok)
     process.exit(1)
 }

--- a/tests/certs.js
+++ b/tests/certs.js
@@ -1,10 +1,10 @@
-'use strict'
+'use strict';
 
-const https = require('https')
+const https = require('https');
 
 // Let's Encrypt should renew when 30 days remain, so if it's less than 25
 // something is wrong with certificate automation.
-const MAX_DAYS = 25
+const MAX_DAYS = 25;
 
 const DOMAINS = [
   'blog.whatwg.org',
@@ -51,44 +51,47 @@ const DOMAINS = [
   'www.whatwg.org',
   'xhr.spec.whatwg.org',
   'xn--7ca.whatwg.org',
-]
+];
 
 function getCertificate(domain) {
   return new Promise((resolve, reject) => {
     const req = https.request(`https://${domain}`, res => {
-      resolve(res.connection.getPeerCertificate())
-    })
-    req.on('error', err => reject(err))
-    req.end()
-  })
+      resolve(res.connection.getPeerCertificate());
+    });
+    req.on('error', err => reject(err));
+    req.end();
+  });
 }
 
 async function test() {
-  const now = Date.now()
+  const now = Date.now();
 
   // start all the requests in parallel
-  const requests = DOMAINS.map(domain => [domain, getCertificate(domain)])
+  const requests = DOMAINS.map(domain => [domain, getCertificate(domain)]);
 
-  let ok = true
+  let ok = true;
 
   for (const [domain, request] of requests) {
-    let status = 'OK'
+    let status = 'OK';
     try {
-      const cert = await request
-      const valid_to = Date.parse(cert.valid_to)
-      const days_left = (valid_to - now) / (24 * 3600 * 1000)
-      if (days_left < MAX_DAYS)
-        status = `cert expires in less than ${MAX_DAYS} days: ${cert.valid_to}`
+      const cert = await request;
+      const valid_to = Date.parse(cert.valid_to);
+      const days_left = (valid_to - now) / (24 * 3600 * 1000);
+      if (days_left < MAX_DAYS) {
+        status = `cert expires in less than ${MAX_DAYS} days: ${cert.valid_to}`;
+      }
     } catch (err) {
       status = err;
     }
-    if (status !== 'OK')
-      ok = false
-    console.log(domain, status)
+    if (status !== 'OK') {
+      ok = false;
+    }
+    console.log(domain, status);
   }
 
-  if (!ok)
-    process.exit(1)
+  if (!ok) {
+    process.exit(1);
+  }
 }
 
-test()
+test();


### PR DESCRIPTION
The idea is that this would be run both after updates to master and as a
daily cron job so that cert issues don't go unnoticed for long.

Similar tests for redirects and other things that shouldn't break would
be a good idea.