### PR TITLE
Rethrow unhandled promise rejections in tests

### DIFF
--- a/tests/certs.js
+++ b/tests/certs.js
@@ -94,4 +94,7 @@ async function test() {
   }
 }
 
-test();
+test().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/redirects.js
+++ b/tests/redirects.js
@@ -191,4 +191,7 @@ async function test() {
   }
 }
 
-test();
+test().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
In https://travis-ci.org/whatwg/misc-server/builds/293854231 this
happened without failing the build:

(node:4452) UnhandledPromiseRejectionWarning: Unhandled promise
rejection (rejection id: 1): FetchError: request to
http://resources.whatwg.org/ failed, reason: connect ETIMEDOUT
165.227.248.76:80
(node:4452) [DEP0018] DeprecationWarning: Unhandled promise rejections
are deprecated. In the future, promise rejections that are not handled
will terminate the Node.js process with a non-zero exit code.