### PR TITLE
Host url.spec.whatwg.org

### DIFF
--- a/debian/marquee/DOMAINS
+++ b/debian/marquee/DOMAINS
@@ -21,6 +21,7 @@ resources.whatwg.org
 spec.whatwg.org,specs.whatwg.org
 storage.spec.whatwg.org
 svn.whatwg.org
+url.spec.whatwg.org
 validator.whatwg.org
 webvtt.spec.whatwg.org
 whatwg.org,www.whatwg.org

--- a/debian/marquee/nginx/sites/url.spec.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/url.spec.whatwg.org.conf
@@ -1,0 +1,28 @@
+server {
+    server_name url.spec.whatwg.org;
+    root /var/www/url.spec.whatwg.org;
+
+    ssl_certificate /etc/letsencrypt/live/url.spec.whatwg.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/url.spec.whatwg.org/privkey.pem;
+
+    include /etc/nginx/whatwg.conf;
+
+    location /interop/ {
+        return 410;
+    }
+    location = /reference-implementation/liveview.html {
+        return 301 https://quuz.org/url/liveview.html;
+    }
+    location = /reference-implementation/liveview2.html {
+        return 301 https://quuz.org/url/liveview2.html;
+    }
+    location = /reference-implementation/liveview3.html {
+        return 301 https://quuz.org/url/liveview3.html;
+    }
+    location = /reference-implementation/uri-validate.html {
+        return 301 https://quuz.org/url/uri-validate.html;
+    }
+    location /reference-implementation/ {
+        return 410;
+    }
+}


### PR DESCRIPTION
The redirects are translated from the .htaccess deleted in
https://github.com/whatwg/url/pull/351 and tested in
https://github.com/whatwg/misc-server/pull/25.