### PR TITLE
Drop the default_type for HTML commit snapshots

### DIFF
--- a/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
@@ -6,11 +6,6 @@ server {
 
     error_page 404 /404.html;
 
-    # Commit snapshots have no file extension
-    location /commit-snapshots/ {
-        default_type text/html;
-    }
-
     # PDF headers
     location = /print.pdf {
         add_header Content-Disposition "inline; filename=html-standard.pdf";


### PR DESCRIPTION
No longer needed:
https://github.com/whatwg/html-build/pull/138