### PR TITLE
Redirect https://whatwg.org/specs/web-socket-protocol/ to IETF

### DIFF
--- a/debian/marquee/nginx/sites/whatwg.org.conf
+++ b/debian/marquee/nginx/sites/whatwg.org.conf
@@ -157,6 +157,9 @@ server {
     location /specs/web-forms/tests {
         return 301 https://github.com/w3c/web-platform-tests;
     }
+    location /specs/web-socket-protocol {
+        return 301 https://tools.ietf.org/html/rfc6455;
+    }
     location = /specs/web-workers/current-work/ {
         return 301 https://html.spec.whatwg.org/multipage/workers.html;
     }

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -166,6 +166,7 @@ const HTTPS_TESTS = [
   ['https://whatwg.org/specs/web-apps/current-work/webvtt.html', 301, 'https://w3c.github.io/webvtt/'],
   ['https://whatwg.org/specs/web-apps/html5', 301, 'https://html.spec.whatwg.org/multipage/', 'keep'],
   ['https://whatwg.org/specs/web-forms/tests', 301, 'https://github.com/w3c/web-platform-tests', 'drop'],
+  ['https://whatwg.org/specs/web-socket-protocol', 301, 'https://tools.ietf.org/html/rfc6455', 'drop'],
   ['https://whatwg.org/specs/web-workers/current-work/', 301, 'https://html.spec.whatwg.org/multipage/workers.html'],
   ['https://whatwg.org/u', 301, 'https://url.spec.whatwg.org/'],
   ['https://whatwg.org/url', 301, 'https://url.spec.whatwg.org/'],


### PR DESCRIPTION
Per error logs, it's the most common 404 on whatwg.org.

Original content:
http://web.archive.org/web/20170202211009/https://whatwg.org/specs/web-socket-protocol/