### PR TITLE
Add X-Content-Type-Options and X-XSS-Protection to noembed

### DIFF
--- a/debian/noembed/nginx/sites/participate.whatwg.org.conf
+++ b/debian/noembed/nginx/sites/participate.whatwg.org.conf
@@ -3,7 +3,9 @@ server {
   ssl_certificate /etc/letsencrypt/live/participate.whatwg.org/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/participate.whatwg.org/privkey.pem;
 
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+  add_header X-Content-Type-Options nosniff;
+  add_header X-XSS-Protection "1; mode=block";
 
   server_name participate.whatwg.org;
 


### PR DESCRIPTION
This matches marquee/nginx/conf/whatwg-headers.conf. Not shared
because there are also CORS headers in there.
  
Fixes https://github.com/whatwg/misc-server/issues/62.