### PR TITLE
Add X-Frame-Options header for participate.whatwg.org

### DIFF
--- a/debian/noembed/nginx/sites/participate.whatwg.org.conf
+++ b/debian/noembed/nginx/sites/participate.whatwg.org.conf
@@ -3,9 +3,10 @@ server {
   ssl_certificate /etc/letsencrypt/live/participate.whatwg.org/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/participate.whatwg.org/privkey.pem;
 
-  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-  add_header X-Content-Type-Options nosniff;
-  add_header X-XSS-Protection "1; mode=block";
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "deny" always;
+  add_header X-XSS-Protection "1; mode=block" always;
 
   server_name participate.whatwg.org;
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

The name "noembed", while it means "no support for <embed>", was picked
in anticipation of embedding in <iframe> not being allowed :)