### PR TITLE
Send more HTTP headers always

### DIFF
--- a/debian/marquee/nginx/conf/whatwg-headers.conf
+++ b/debian/marquee/nginx/conf/whatwg-headers.conf
@@ -1,4 +1,4 @@
-add_header Access-Control-Allow-Origin "*";
-add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";
+add_header Access-Control-Allow-Origin "*" always;
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
This means for error pages as well.

Matches changes in https://github.com/whatwg/misc-server/pull/73.