### PR TITLE
Change participate.whatwg.org startup script

### DIFF
--- a/debian/noembed/04-participate
+++ b/debian/noembed/04-participate
@@ -10,4 +10,4 @@ sudo -u noderunner npm install
 
 read -p "Copy private-config.sample.json to private-config.json and fill in all the values appropriately. Then press enter to continue"
 
-echo "@reboot cd $PARTICIPATE_DIR && pm2 start -i 4 --name=participate npm -- start" | sudo -u noderunner crontab -
+echo "@reboot cd $PARTICIPATE_DIR && pm2 start -i 4 --name=participate lib/app.js" | sudo -u noderunner crontab -


### PR DESCRIPTION
This appears to fix https://github.com/whatwg/participate.whatwg.org/issues/18, when I tried changing this live on the server. Something about npm getting in the way, or perhaps not quoting `"npm -- start"` even.