### PR TITLE
Add more redirects for HTML-spec URLs

### DIFF
--- a/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
@@ -11,6 +11,8 @@ server {
         add_header Content-Disposition "inline; filename=html-standard.pdf";
     }
 
+    ## Redirects ##
+
     # Previously-generated filenames for /multipage/ that do not redirect via script:
     location = /multipage/embedded-content-0.html {
         return 301 /multipage/embedded-content.html;
@@ -81,5 +83,1724 @@ server {
     }
     location = /demos/offline/clock/clock.html {
         return 301 /demos/offline/clock/clock2.html;
+    }
+
+    # Mostly for redirects originating from http://w3c.github.io/html/
+    location = /acknowledgements.html {
+        return 301 /multipage/acknowledgements.html;
+    }
+    location = /a.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /apis-in-html-documents.html {
+        return 301 /multipage/dynamic-markup-insertion.html;
+    }
+    location = /article.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /association-of-controls-and-forms.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /attributes-common-to-form-controls.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /attributes-common-to-ins-and-del-elements.html {
+        return 301 /multipage/edits.html;
+    }
+    location = /attributes-common-to-td-and-th-elements.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /b.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /browsers.html {
+        return 301 /multipage/browsers.html;
+    }
+    location = /browsing-the-web.html {
+        return 301 /multipage/browsing-the-web.html;
+    }
+    location = /canvas.html {
+        return 301 /multipage/canvas.html;
+    }
+    location = /changes.html {
+        return 301 /multipage/introduction.html;
+    }
+    location = /commands.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /common-dom-interfaces.html {
+        return 301 /multipage/common-dom-interfaces.html;
+    }
+    location = /common-idioms.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /common-idioms-without-dedicated-elements.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /common-input-element-apis.html {
+        return 301 /multipage/input.html;
+    }
+    location = /common-input-element-attributes.html {
+        return 301 /multipage/input.html;
+    }
+    location = /common-microsyntaxes.html {
+        return 301 /multipage/common-microsyntaxes.html;
+    }
+    location = /comms.html {
+        return 301 /multipage/comms.html;
+    }
+    location = /constraints.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /content-models.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /converting-html-to-other-formats.html {
+        return 301 /multipage/microdata.html;
+    }
+    location = /custom-elements.html {
+        return 301 /multipage/custom-elements.html;
+    }
+    location = /dimension-attributes.html {
+        return 301 /multipage/embedded-content-other.html;
+    }
+    location = /disabled-elements.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /dnd.html {
+        return 301 /multipage/dnd.html;
+    }
+    location = /document-metadata.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /dom.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /dynamic-markup-insertion.html {
+        return 301 /multipage/dynamic-markup-insertion.html;
+    }
+    location = /editing.html {
+        return 301 /multipage/interaction.html;
+    }
+    location = /editing-apis.html {
+        return 301 /multipage/interaction.html;
+    }
+    location = /edits.html {
+        return 301 /multipage/edits.html;
+    }
+    location = /edits-and-lists.html {
+        return 301 /multipage/edits.html;
+    }
+    location = /element-definitions.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /elements.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /embedded-content-0.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /embedded-content-1.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /embedded-content.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /embedded-content-other.html {
+        return 301 /multipage/embedded-content-other.html;
+    }
+    location = /form-control-infrastructure.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /form-elements.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /form-submission.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /forms.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /fullindex.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /global-attributes.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /grouping-content.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /headings-and-sections.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /history.html {
+        return 301 /multipage/history.html;
+    }
+    location = /the-hr-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /iana.html {
+        return 301 /multipage/iana.html;
+    }
+    location = /iana-considerations.html {
+        return 301 /multipage/iana.html;
+    }
+    location = /idl-index.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /iframe-embed-object.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /imagebitmap-and-animations.html {
+        return 301 /multipage/imagebitmap-and-animations.html;
+    }
+    location = /image-maps.html {
+        return 301 /multipage/image-maps.html;
+    }
+    location = /images.html {
+        return 301 /multipage/images.html;
+    }
+    location = /indices.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /infrastructure.html {
+        return 301 /multipage/infrastructure.html;
+    }
+    location = /input.html {
+        return 301 /multipage/input.html;
+    }
+    location = /interaction.html {
+        return 301 /multipage/interaction.html;
+    }
+    location = /interactions-with-xpath-and-xslt.html {
+        return 301 /multipage/infrastructure.html;
+    }
+    location = /interactive-elements.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /introduction.html {
+        return 301 /multipage/introduction.html;
+    }
+    location = /links.html {
+        return 301 /multipage/links.html;
+    }
+    location = /main.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /matching-html-elements-using-selectors.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /mathml.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /media.html {
+        return 301 /multipage/media.html;
+    }
+    location = /media-elements.html {
+        return 301 /multipage/media.html;
+    }
+    location = /microdata.html {
+        return 301 /multipage/microdata.html;
+    }
+    location = /microdata/master/Overview.html {
+        return 301 /multipage/microdata.html;
+    }
+    location = /named-character-references.html {
+        return 301 /multipage/named-characters.html;
+    }
+    location = /named-characters.html {
+        return 301 /multipage/named-characters.html;
+    }
+    location = /network.html {
+        return 301 /multipage/web-sockets.html;
+    }
+    location = /number-state.html {
+        return 301 /multipage/input.html;
+    }
+    location = /obsolete.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /offline.html {
+        return 301 /multipage/offline.html;
+    }
+    location = /origin.html {
+        return 301 /multipage/origin.html;
+    }
+    location = /origin-0.html {
+        return 301 /multipage/origin.html;
+    }
+    location = /overview.html {
+        return 301 /multipage/;
+    }
+    location = /Overview.html {
+        return 301 /multipage/;
+    }
+    location = /parsing.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /property-index.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /references.html {
+        return 301 /multipage/references.html;
+    }
+    location = /rendering.html {
+        return 301 /multipage/rendering.html;
+    }
+    location = /requirements-relating-to-bidirectional-algorithm-formatting-characters.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /scripting-1.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /scripting.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /sec-forms.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /section-index.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /sections.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /selectors.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /semantics.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /semantics-embedded-content.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /semantics-other.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /semantics-scripting.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /server-sent-events.html {
+        return 301 /multipage/server-sent-events.html;
+    }
+    location = /single-page.html {
+        return 301 /;
+    }
+    location = /spec.html {
+        return 301 /multipage/;
+    }
+    location = /states-of-the-type-attribute.html {
+        return 301 /multipage/input.html;
+    }
+    location = /structured-data.html {
+        return 301 /multipage/structured-data.html;
+    }
+    location = /svg-0.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /system-state-and-capabilities.html {
+        return 301 /multipage/system-state.html;
+    }
+    location = /system-state.html {
+        return 301 /multipage/system-state.html;
+    }
+    location = /syntax.html {
+        return 301 /multipage/syntax.html;
+    }
+    location = /tabular-data.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /tables.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /textFieldSelection.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /textfieldselection.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /text-level-semantics.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /textlevel-semantics.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-a-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-abbr-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-address-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-area-element.html {
+        return 301 /multipage/image-maps.html;
+    }
+    location = /the-article-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-aside-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-audio-element.html {
+        return 301 /multipage/media.html;
+    }
+    location = /the-b-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-base-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-blockquote-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-bdi-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-bdo-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-body-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-br-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-button-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-canvas-element.html {
+        return 301 /multipage/canvas.html;
+    }
+    location = /the-caption-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-cite-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-code-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-col-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-colgroup-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-command-element.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /the-datalist-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-dd-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-del-element.html {
+        return 301 /multipage/edits.html;
+    }
+    location = /the-details-element.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /the-div-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-dl-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-dfn-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-dt-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-embed-element.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /the-em-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-end.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /fetching-resources.html {
+        return 301 /multipage/urls-and-fetching.html;
+    }
+    location = /the-fieldset-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-figcaption-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-figure-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-footer-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-form-element.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /the-h1-h2-h3-h4-h5-and-h6-elements.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-head-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-header-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-hgroup-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-html-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-i-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-iframe-element.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /the-img-element.html {
+        return 301 /multipage/embedded-content-other.html;
+    }
+    location = /the-input-element.html {
+        return 301 /multipage/input.html;
+    }
+    location = /the-ins-element.html {
+        return 301 /multipage/edits.html;
+    }
+    location = /the-kbd-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-keygen-element.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /the-label-element.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /the-legend-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-li-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-link-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-map-element.html {
+        return 301 /multipage/image-maps.html;
+    }
+    location = /the-mark-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-menu-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-meta-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-meter-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-nav-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-noscript-element.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /the-object-element.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /the-ol-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-optgroup-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-option-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-output-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-p-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-param-element.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /the-pre-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-progress-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-q-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-root-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-rp-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-rt-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-ruby-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-s-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-samp-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-script-element.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /the-section-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /the-select-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-small-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-source-element.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /the-span-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-strong-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-style-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-sub-and-sup-elements.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-summary-element.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /the-tbody-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-textarea-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /the-table-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-td-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-tfoot-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-th-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-thead-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-time-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-title-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /the-tr-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /the-track-element.html {
+        return 301 /multipage/media.html;
+    }
+    location = /the-u-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-ul-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /the-var-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-video-element.html {
+        return 301 /multipage/media.html;
+    }
+    location = /the-wbr-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /the-xhtml-syntax.html {
+        return 301 /multipage/xhtml.html;
+    }
+    location = /timers.html {
+        return 301 /multipage/timers-and-user-prompts.html;
+    }
+    location = /timers-and-user-prompts.html {
+        return 301 /multipage/timers-and-user-prompts.html;
+    }
+    location = /toc-status.html {
+        return 301 /multipage/;
+    }
+    location = /tokenization.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /tree-construction.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /urls.html {
+        return 301 /multipage/urls-and-fetching.html;
+    }
+    location = /urls-and-fetching.html {
+        return 301 /multipage/urls-and-fetching.html;
+    }
+    location = /user-prompts.html {
+        return 301 /multipage/user-prompts.html;
+    }
+    location = /video.html {
+        return 301 /multipage/media.html;
+    }
+    location = /video-conferencing-and-peer-to-peer-communication.html {
+        return 301 https://w3c.github.io/webrtc-pc/;
+    }
+    location = /wai-aria.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /webappapis.html {
+        return 301 /multipage/webappapis.html;
+    }
+    location = /web-messaging.html {
+        return 301 /multipage/web-messaging.html;
+    }
+    location = /web-sockets.html {
+        return 301 /multipage/web-sockets.html;
+    }
+    location = /webstorage.html {
+        return 301 /multipage/webstorage.html;
+    }
+    location = /window-object.html {
+        return 301 /multipage/window-object.html;
+    }
+    location = /workers.html {
+        return 301 /multipage/workers.html;
+    }
+    location = /xhtml.html {
+        return 301 /multipage/xhtml.html;
+    }
+
+    # Multipage; mostly for redirects from W3C TR/html and other older forks
+    location = /multipage/a.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/a-map-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/abbr.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/acknowledgments.html {
+        return 301 /multipage/acknowledgements.html;
+    }
+    location = /multipage/address.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/alt.html {
+        return 301 /multipage/images.html;
+    }
+    location = /multipage/apis-in-html-documents.html {
+        return 301 /multipage/dynamic-markup-insertion.html;
+    }
+    location = /multipage/area.html {
+        return 301 /multipage/image-maps.html;
+    }
+    location = /multipage/aside.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/association-of-controls-and-forms.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /multipage/attributes.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /multipage/attributes-common-to-form-controls.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /multipage/attributes-common-to-td-and-th-elements.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/audio.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/b.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/base.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/bdi.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/bdo.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/blockquote.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/body.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/br.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/button.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/button.button.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/button.reset.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/button.submit.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/caption.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/changes.html {
+        return 301 /multipage/introduction.html;
+    }
+    location = /multipage/cite.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/code.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/col.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/colgroup.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/command.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/command.checkbox.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/command.command.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/command.radio.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/commands.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /multipage/common-idioms.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /multipage/common-idioms-without-dedicated-elements.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /multipage/common-input-element-apis.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/common-input-element-attributes.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/common-models.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /multipage/constraints.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /multipage/content-models.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /multipage/converting-html-to-other-formats.html {
+        return 301 /multipage/microdata.html;
+    }
+    location = /multipage/datalist.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/datatypes.html {
+        return 301 /multipage/common-microsyntaxes.html;
+    }
+    location = /multipage/dd.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/del.html {
+        return 301 /multipage/edits.html;
+    }
+    location = /multipage/details.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /multipage/dfn.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/dimension-attributes.html {
+        return 301 /multipage/embedded-content-other.html;
+    }
+    location = /multipage/disabled-elements.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /multipage/div.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/document-metadata.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/dl.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/documents.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /multipage/dt.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/editing.html {
+        return 301 /multipage/interaction.html;
+    }
+    location = /multipage/editing-apis.html {
+        return 301 /multipage/interaction.html;
+    }
+    location = /multipage/elements.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /multipage/elements-by-function.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /multipage/em.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/embed.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /multipage/embedded0.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/embedded-content-1.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/fetching-resources.html {
+        return 301 /multipage/urls-and-fetching.html;
+    }
+    location = /multipage/fieldset.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/figure.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/footer.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/form.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /multipage/form-submission.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /multipage/fullindex.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /multipage/global-attributes.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /multipage/h1.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/h2.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/h3.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/h4.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/h5.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/h6.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/header.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/head.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/headings-and-sections.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/hgroup.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/hr.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/html.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/idl-index.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /multipage/iframe.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /multipage/imagebitmap-and-animations.html.html {
+        return 301 /multipage/imagebitmap-and-animations.html;
+    }
+    location = /multipage/img.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/input.button.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.checkbox.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.color.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.date.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.datetime.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.datetime-local.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.email.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.file.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.hidden.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.image.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.month.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.number.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.password.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.range.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.radio.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.reset.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.search.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.submit.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.tel.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.text.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.time.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.url.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/input.week.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/ins.html {
+        return 301 /multipage/edits.html;
+    }
+    location = /multipage/interactions-with-xpath-and-xslt.html {
+        return 301 /multipage/infrastructure.html;
+    }
+    location = /multipage/intro.html {
+        return 301 /multipage/introduction.html;
+    }
+    location = /multipage/kbd.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/keygen.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/label.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /multipage/legend.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/li.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/link.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/main.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/map.html {
+        return 301 /multipage/image-maps.html;
+    }
+    location = /multipage/mark.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/matching-html-elements-using-selectors.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /multipage/mathml.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/media-elements.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/menu.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/meta.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/meta.charset.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/meta.http-equiv.content-language.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/meta.http-equiv.content-type.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/meta.http-equiv.default-style.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/meta.http-equiv.refresh.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/meta.name.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/meter.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/multipage/obsolete.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/named-character-references.html {
+        return 301 /multipage/named-characters.html;
+    }
+    location = /multipage/named.html {
+        return 301 /multipage/named-characters.html;
+    }
+    location = /multipage/nav.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/network.html {
+        return 301 /multipage/web-sockets.html;
+    }
+    location = /multipage/noscript.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /multipage/number-state.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/object.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /multipage/obsolete-features.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/ol.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/optgroup.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/option.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/origin-0.html {
+        return 301 /multipage/origin.html;
+    }
+    location = /multipage/output.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/overview.html {
+        return 301 /multipage/;
+    }
+    location = /multipage/Overview.html {
+        return 301 /multipage/;
+    }
+    location = /multipage/p.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/param.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /multipage/pre.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/q.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/progress.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/property-index.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /multipage/rp.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/rt.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/ruby.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/s.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/samp.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/script.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /multipage/sec-forms.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /multipage/section.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/section-browser.html {
+        return 301 /multipage/browsers.html;
+    }
+    location = /multipage/section-conformance.html {
+        return 301 /multipage/infrastructure.html;
+    }
+    location = /multipage/section-contenteditable.html {
+        return 301 /multipage/interaction.html;
+    }
+    location = /multipage/section-crossDocumentMessages.html {
+        return 301 /multipage/web-messaging.html;
+    }
+    location = /multipage/section-embedded.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/section-grouping.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/section-index.html {
+        return 301 /multipage/indices.html;
+    }
+    location = /multipage/section-interactive-elements.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /multipage/section-links.html {
+        return 301 /multipage/links.html;
+    }
+    location = /multipage/section-origin.html {
+        return 301 /multipage/origin.html;
+    }
+    location = /multipage/section-parsing.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /multipage/section-scripting.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /multipage/section-sections.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/section-server-sent-events.html {
+        return 301 /multipage/server-sent-events.html;
+    }
+    location = /multipage/section-structured.html {
+        return 301 /multipage/structured-data.html;
+    }
+    location = /multipage/section-the-canvas.html {
+        return 301 /multipage/canvas.html;
+    }
+    location = /multipage/section-tree-construction.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /multipage/section-video.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/section-writing0.html {
+        return 301 /multipage/syntax.html;
+    }
+    location = /multipage/section-writing.html {
+        return 301 /multipage/syntax.html;
+    }
+    location = /multipage/select.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/selectors.html {
+        return 301 /multipage/semantics-other.html;
+    }
+    location = /multipage/semantics-embedded-content.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/semantics-scripting.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /multipage/serializing-html-fragments.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /multipage/shadow-dom.html {
+        return 301 https://dom.spec.whatwg.org/;
+    }
+    location = /multipage/single-page.html {
+        return 301 /;
+    }
+    location = /multipage/span.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/spec.html {
+        return 301 /multipage/;
+    }
+    location = /multipage/small.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/source.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/states-of-the-type-attribute.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/strong.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/structured.html {
+        return 301 /multipage/structured-data.html;
+    }
+    location = /multipage/structured-client-side-storage.html {
+        return 301 /multipage/webstorage.html;
+    }
+    location = /multipage/style.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/sub.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/sup.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/summary.html {
+        return 301 /multipage/interactive-elements.html;
+    }
+    location = /multipage/system-state-and-capabilities.html {
+        return 301 /multipage/system-state.html;
+    }
+    location = /multipage/table.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/tabular.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/tbody.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/td.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/tfoot.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/terminology.html {
+        return 301 /multipage/infrastructure.html;
+    }
+    location = /multipage/textarea.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/textFieldSelection.html {
+        return 301 /multipage/form-control-infrastructure.html;
+    }
+    location = /multipage/textlevel-semantics.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/th.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/thead.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/the-a-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-abbr-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-article-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-aside-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-audio-element.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/the-b-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-bdi-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-blockquote-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-body-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-br-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-button-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-canvas.html {
+        return 301 /multipage/canvas.html;
+    }
+    location = /multipage/the-canvas-element.html {
+        return 301 /multipage/canvas.html;
+    }
+    location = /multipage/the-caption-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/the-cite-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-code-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-command-element.html {
+        return 301 /multipage/obsolete.html;
+    }
+    location = /multipage/the-datalist-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-dd-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-dfn-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-dl-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-embed-element.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /multipage/the-end.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /multipage/the-footer-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-form-element.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /multipage/the-h1-h2-h3-h4-h5-and-h6-elements.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-head-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/the-header-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-hr-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-html-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/the-i-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-iframe-element.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /multipage/the-img-element.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/the-input-element.html {
+        return 301 /multipage/input.html;
+    }
+    location = /multipage/the-kbd-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-label-element.html {
+        return 301 /multipage/forms.html;
+    }
+    location = /multipage/the-link-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/the-map-element.html {
+        return 301 /multipage/image-maps.html;
+    }
+    location = /multipage/the-mark-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-li-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-menu-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-meta-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/the-meter-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-nav-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-object-element.html {
+        return 301 /multipage/iframe-embed-object.html;
+    }
+    location = /multipage/the-optgroup-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-option-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-p-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-progress-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-root.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/the-rt-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-ruby-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-samp-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-pre-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-script-element.html {
+        return 301 /multipage/scripting.html;
+    }
+    location = /multipage/the-section-element.html {
+        return 301 /multipage/sections.html;
+    }
+    location = /multipage/the-select-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-source-element.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /multipage/the-strong-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-style-element.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/the-sub-and-sup-elements.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-table-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/the-td-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/the-textarea-element.html {
+        return 301 /multipage/form-elements.html;
+    }
+    location = /multipage/the-tfoot-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/the-th-element.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/the-time-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-track-element.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/the-ul-element.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/the-var-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-video-element.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/the-wbr-element.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/the-xhtml-syntax.html {
+        return 301 /multipage/xhtml.html;
+    }
+    location = /multipage/time.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/timers.html {
+        return 301 /multipage/timers-and-user-prompts.html;
+    }
+    location = /multipage/title.html {
+        return 301 /multipage/semantics.html;
+    }
+    location = /multipage/tokenization.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /multipage/tr.html {
+        return 301 /multipage/tables.html;
+    }
+    location = /multipage/track.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/tree-construction.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /multipage/u.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/ul.html {
+        return 301 /multipage/grouping-content.html;
+    }
+    location = /multipage/urls.html {
+        return 301 /multipage/urls-and-fetching.html;
+    }
+    location = /multipage/user-prompts.html {
+        return 301 /multipage/user-prompts.html;
+    }
+    location = /multipage/var.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+    location = /multipage/video.html {
+        return 301 /multipage/media.html;
+    }
+    location = /multipage/video-conferencing-and-peer-to-peer-communication.html {
+        return 301 https://w3c.github.io/webrtc-pc/;
+    }
+    location = /multipage/wai-aria.html {
+        return 301 /multipage/dom.html;
+    }
+    location = /multipage/wbr.html {
+        return 301 /multipage/text-level-semantics.html;
+    }
+
+    # Developer edition
+    location = /dev/acknowledgments.html {
+        return 301 /dev/acknowledgements.html;
+    }
+    location = /dev/apis-in-html-documents.html {
+        return 301 /dev/dynamic-markup-insertion.html;
+    }
+    location = /dev/association-of-controls-and-forms.html {
+        return 301 /dev/form-control-infrastructure.html;
+    }
+    location = /dev/commands.html {
+        return 301 /dev/form-control-infrastructure.html;
+    }
+    location = /dev/common-input-element-attributes.html {
+        return 301 /dev/input.html;
+    }
+    location = /dev/content-models.html {
+        return 301 /dev/dom.html;
+    }
+    location = /dev/editing.html {
+        return 301 /dev/interaction.html;
+    }
+    location = /dev/elements.html {
+        return 301 /dev/dom.html;
+    }
+    location = /dev/embedded-content-1.html {
+        return 301 /multipage/embedded-content.html;
+    }
+    location = /dev/iana.html {
+        return 301 /multipage/iana.html;
+    }
+    location = /dev/named-character-references.html {
+        return 301 /dev/named-characters.html;
+    }
+    location = /dev/number-state.html {
+        return 301 /dev/number-state.html;
+    }
+    location = /dev/origin-0.html {
+        return 301 /dev/origin.html;
+    }
+    location = /dev/parsing.html {
+        return 301 /multipage/parsing.html;
+    }
+    location = /dev/scripting-1.html {
+        return 301 /dev/scripting.html;
+    }
+    location = /dev/section-index.html {
+        return 301 /dev/indices.html;
+    }
+    location = /dev/states-of-the-type-attribute.html {
+        return 301 /dev/input.html;
+    }
+    location = /dev/tabular-data.html {
+        return 301 /dev/tables.html;
+    }
+    location = /dev/the-button-element.html {
+        return 301 /dev/form-elements.html;
+    }
+    location = /dev/the-canvas-element.html {
+        return 301 /dev/canvas.html;
+    }
+    location = /dev/the-iframe-element.html {
+        return 301 /dev/iframe-embed-object.html;
+    }
+    location = /dev/the-input-element.html {
+        return 301 /dev/input.html;
+    }
+    location = /dev/the-map-element.html {
+        return 301 /dev/image-maps.html;
+    }
+    location = /dev/the-video-element.html {
+        return 301 /dev/media.html;
+    }
+    location = /dev/the-xhtml-syntax.html {
+        return 301 /dev/xhtml.html;
+    }
+    location = /dev/timers.html {
+        return 301 /dev/timers-and-user-prompts.html;
+    }
+    location = /dev/urls.html {
+        return 301 /dev/urls-and-fetching.html;
+    }
+    location = /dev/video.html {
+        return 301 /dev/media.html;
+    }
+    location = /dev/video-conferencing-and-peer-to-peer-communication.html {
+        return 301 https://w3c.github.io/webrtc-pc/;
     }
 }


### PR DESCRIPTION
This change adds a large number of redirects for HTML-spec URLs. They’re mostly for handling pathnames for files that were part of W3C HTML forks but for which there aren’t (now) any files with the same names.

Otherwise, without adding these redirects, we are getting a large number of 404s logged for broken links coming in from those W3C redirects.

The set of redirects added here was put together based on analyzing/grepping the nginx logs for 404s.