### PR TITLE
Test X-Frame-Options header for blog and wiki

### DIFF
--- a/test/x-headers.js
+++ b/test/x-headers.js
@@ -6,17 +6,13 @@ const fetch = require('node-fetch');
 const TEST_DATA = [
   // not an exhaustive list, just enough to catch accidental removal
   ['whatwg.org', 'nosniff', null, '1; mode=block'],
-  // FIXME: blog.whatwg.org should use x-frame-options deny
-  // https://github.com/whatwg/misc-server/issues/108
-  ['blog.whatwg.org', 'nosniff', null, '1; mode=block'],
+  ['blog.whatwg.org', 'nosniff', 'sameorigin', '1; mode=block'],
   ['dom.spec.whatwg.org', 'nosniff', null, '1; mode=block'],
   ['participate.whatwg.org', 'nosniff', 'deny', '1; mode=block'],
   ['resources.whatwg.org', 'nosniff', null, '1; mode=block'],
   ['spec.whatwg.org', 'nosniff', null, '1; mode=block'],
-  // FIXME: wiki.whatwg.org should use x-frame-options, and shouldn't send
-  // double x-content-type-options headers
-  // https://github.com/whatwg/misc-server/issues/108
-  ['wiki.whatwg.org', 'nosniff, nosniff', null, '1; mode=block'],
+  // FIXME: don't send double x-content-type-options headers
+  ['wiki.whatwg.org', 'nosniff, nosniff', 'sameorigin', '1; mode=block'],
 ];
 
 describe('x-* headers', function() {


### PR DESCRIPTION
The actual fix isn't tracked by version control, it is to add
`Header always set X-Frame-Options: "sameorigin"` to
/etc/apache2/conf-enabled/zz_local.conf on multicol.

Fixes https://github.com/whatwg/misc-server/issues/108.