### PR TITLE
Drop the allowed trailing semicolon in HSTS header test

### DIFF
--- a/test/hsts.js
+++ b/test/hsts.js
@@ -21,11 +21,6 @@ describe('strict-transport-security header', function() {
       const response = await fetch(`https://${hostname}/`, { redirect: 'manual' });
       assert.strictEqual(response.status, 200);
       let value = response.headers.get('strict-transport-security');
-      // Trim any trailing semicolon.
-      // FIXME: https://github.com/whatwg/misc-server/issues/109
-      if (value.endsWith(';')) {
-        value = value.substr(0, value.length - 1);
-      }
       assert.strictEqual(value, 'max-age=63072000; includeSubDomains; preload');
     });
   }


### PR DESCRIPTION
blog.whatwg.org and wiki.whatwg.org had a trailing semicolon, which
has already been removed. This test therefore already passes, but
would catch a reintroduction of the semicolon.

Fixes https://github.com/whatwg/misc-server/issues/109.