### PR TITLE
Remove /google2569a0eb653e4cf1.html redirect

### DIFF
--- a/debian/marquee/nginx/sites/whatwg.org.conf
+++ b/debian/marquee/nginx/sites/whatwg.org.conf
@@ -82,9 +82,6 @@ server {
     location ~ ^/demos/workers(/(.*))?$ {
         return 301 https://html.spec.whatwg.org/demos/workers/$2;
     }
-    location = /google2569a0eb653e4cf1.html {
-        return 301 https://whatwg.org/;
-    }
     location ~ ^/images(/(.*))?$ {
         return 302 https://images.whatwg.org/$2;
     }

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -129,7 +129,6 @@ const HTTPS_TESTS = [
   ['https://whatwg.org/fetch', 301, 'https://fetch.spec.whatwg.org/'],
   ['https://whatwg.org/fs', 301, 'https://fullscreen.spec.whatwg.org/'],
   ['https://whatwg.org/fullscreen', 301, 'https://fullscreen.spec.whatwg.org/'],
-  ['https://whatwg.org/google2569a0eb653e4cf1.html', 301, 'https://whatwg.org/'],
   ['https://whatwg.org/html', 301, 'https://html.spec.whatwg.org/multipage/', 'keep'],
   ['https://whatwg.org/html5', 301, 'https://html.spec.whatwg.org/multipage/', 'keep'],
   ['https://whatwg.org/images', 302, 'https://images.whatwg.org/'],


### PR DESCRIPTION
This must have been for some kind of domain verification, but we don't
use it any more.