### PR TITLE
Configure and test lists.whatwg.org

### DIFF
--- a/debian/marquee/DOMAINS
+++ b/debian/marquee/DOMAINS
@@ -21,6 +21,7 @@ idea.whatwg.org
 images.whatwg.org
 infra.spec.whatwg.org
 javascript.spec.whatwg.org
+lists.whatwg.org
 mediasession.spec.whatwg.org
 mimesniff.spec.whatwg.org
 n.whatwg.org

--- a/debian/marquee/nginx/sites/lists.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/lists.whatwg.org.conf
@@ -1,0 +1,18 @@
+server {
+    server_name lists.whatwg.org;
+    root /var/www/lists.whatwg.org;
+
+    include /etc/nginx/whatwg.conf;
+
+    location = / {
+        return 302 /listinfo.cgi;
+    }
+
+    location ~ ^/htdig.cgi(/(.*))?$ {
+        return 301 /pipermail/$2;
+    }
+
+    default_type text/html;
+
+    error_page 404 /404;
+}

--- a/test/certs.js
+++ b/test/certs.js
@@ -27,7 +27,7 @@ const DOMAINS = [
   'help.whatwg.org',
   'html-differences.whatwg.org',
   'html.spec.whatwg.org',
-  // 'lists.whatwg.org', // https://github.com/whatwg/misc-server/issues/75
+  'lists.whatwg.org',
   'idea.whatwg.org',
   'images.whatwg.org',
   'infra.spec.whatwg.org',

--- a/test/cors.js
+++ b/test/cors.js
@@ -14,7 +14,6 @@ const CORS_TESTS = [
 const NO_CORS_TESTS = [
   // domains for which it's probably a mistake to have CORS headers
   'https://blog.whatwg.org/',
-  //'https://lists.whatwg.org/', // https://github.com/whatwg/misc-server/issues/75
   'https://participate.whatwg.org/',
   'https://wiki.whatwg.org/',
 ];

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -33,7 +33,7 @@ const HTTP_TESTS = [
   ['http://images.whatwg.org/', 301, 'https://images.whatwg.org/', 'keep'],
   ['http://infra.spec.whatwg.org/', 301, 'https://infra.spec.whatwg.org/', 'keep'],
   ['http://javascript.spec.whatwg.org/', 301, 'https://javascript.spec.whatwg.org/', 'keep'],
-  // ['http://lists.whatwg.org/', 302, 'http://lists.whatwg.org/listinfo.cgi'], // https://github.com/whatwg/misc-server/issues/75
+  ['http://lists.whatwg.org/', 301, 'https://lists.whatwg.org/', 'keep'],
   ['http://mediasession.spec.whatwg.org/', 301, 'https://mediasession.spec.whatwg.org/', 'keep'],
   ['http://mimesniff.spec.whatwg.org/', 301, 'https://mimesniff.spec.whatwg.org/', 'keep'],
   ['http://n.whatwg.org/', 301, 'https://n.whatwg.org/', 'keep'],
@@ -90,6 +90,8 @@ const HTTPS_TESTS = [
   ['https://html.spec.whatwg.org/multipage/section-sql.html', 410],
   ['https://html.spec.whatwg.org/multipage/tabular-data.html', 301, 'https://html.spec.whatwg.org/multipage/tables.html'],
   ['https://javascript.spec.whatwg.org/', 302, 'https://github.com/tc39/ecma262/labels/web%20reality', 'drop'],
+  ['https://lists.whatwg.org/', 302, 'https://lists.whatwg.org/listinfo.cgi'],
+  ['https://lists.whatwg.org/htdig.cgi', 301, 'https://lists.whatwg.org/pipermail/', 'keep'],
   ['https://mediasession.spec.whatwg.org/', 302, 'https://wicg.github.io/mediasession/', 'drop'],
   ['https://resources.whatwg.org/logo-mime.png', 301, 'https://resources.whatwg.org/logo-mimesniff.png'],
   ['https://resources.whatwg.org/logo-mime.svg', 301, 'https://resources.whatwg.org/logo-mimesniff.svg'],


### PR DESCRIPTION
The contents are https://github.com/whatwg/lists.whatwg.org which is
currently private, and will either be made public or merged into the
whatwg.org when it's clear how big it will be once more complete.