### PR TITLE
Update setup scripts for marquee to work on Debian 10

### DIFF
--- a/debian/common/00-upgrade
+++ b/debian/common/00-upgrade
@@ -4,5 +4,6 @@ apt update -y
 apt upgrade -y
 apt autoremove -y
 
+# TODO: this is redundant on Debian 10, remove when we have no Debian 9
 echo "Etc/UTC" > /etc/timezone
 dpkg-reconfigure -f noninteractive tzdata

--- a/debian/common/04-ssh
+++ b/debian/common/04-ssh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-apt install -y openssh-server
+apt install -y openssh-server rsync
 
 read -p "ssh password login will be disabled, press enter to continue"
 

--- a/debian/common/scripts/certbot
+++ b/debian/common/scripts/certbot
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# This setup is used on Debian 9
+# TODO: remove when we no longer have any Debian 9 VMs
+
 # enable backports to get a newer certbot
 sed -i 's/# \(deb.*stretch-backports.*\)/\1/' /etc/apt/sources.list
 apt update

--- a/debian/common/scripts/certbot-dns
+++ b/debian/common/scripts/certbot-dns
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+# This setup is used on Debian 10
+
+DIGITALOCEAN_INI=/etc/letsencrypt/digitalocean.ini
+
+token=""
+while [ -z "$token" ]; do
+  read -p "DigitalOcean access token: " token
+done
+
+echo "dns_digitalocean_token = $token" > "$DIGITALOCEAN_INI"
+chmod 0600 "$DIGITALOCEAN_INI"
+
+apt install certbot python3-certbot-dns-digitalocean
+
+DOMAINS_FILE="$1"
+
+# https://stackoverflow.com/a/8714446
+DOMAIN_ARG="$(cat "$DOMAINS_FILE" | awk -vORS=, '{ print }' | sed 's/,$//')"
+certbot certonly --agree-tos --dns-digitalocean --dns-digitalocean-credentials "$DIGITALOCEAN_INI" -m admin@whatwg.org -d "$DOMAIN_ARG"
+
+# https://www.dzombak.com/blog/2018/01/Deploying-Let-s-Encrypt-with-Nginx-on-Ubuntu-16-04.html
+mkdir -p /etc/letsencrypt/renewal-hooks/deploy
+cp "$(dirname "$0")/certbot-renewal-hooks-deploy-nginx" /etc/letsencrypt/renewal-hooks/deploy/nginx

--- a/debian/marquee/01-certbot
+++ b/debian/marquee/01-certbot
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-../common/scripts/certbot DOMAINS
+../common/scripts/certbot-dns DOMAINS


### PR DESCRIPTION
marquee is still running on the same Debian 9 instance, but these
scripts have been tested on a new Debian 10 instance on DigitalOcean.