### PR TITLE
Migrate tests to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+  schedule:
+  - cron: '44 13 * * *'
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: test
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    - run: npm install
+    - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - master
   schedule:
+  # 13:44 is an arbitrarily chosen daily time.
   - cron: '44 13 * * *'
 jobs:
   test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-branches:
-  only:
-    - master
-language: node_js
-node_js: stable
-before_install:
-  - cd test

--- a/test/package.json
+++ b/test/package.json
@@ -1,9 +1,10 @@
 {
+  "private": true,
   "dependencies": {
     "mocha": "^8.0.1",
     "node-fetch": "^2.6.0"
   },
   "scripts": {
-    "test": "mocha --timeout=10000 --retries=3 *.js"
+    "test": "mocha --color --timeout=10000 --retries=3 *.js"
   }
 }


### PR DESCRIPTION
The 13:44 trigger was chosen simply to match when Travis has been
triggering: https://api.github.com/repos/whatwg/misc-server/statuses/f8fd9dd5001bc14b277a734a4267226b73534e4c

It's not important to match that, but there is not default, and choosing
UTC midnight would lead to a spike in CI usage if we all did that.

Part of https://github.com/whatwg/meta/issues/173.