### PR TITLE
Enable colors in mocha output using environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,5 @@ jobs:
         node-version: 14
     - run: npm install
     - run: npm test
+      env:
+        FORCE_COLOR: 3

--- a/test/package.json
+++ b/test/package.json
@@ -5,6 +5,6 @@
     "node-fetch": "^2.6.0"
   },
   "scripts": {
-    "test": "mocha --color --timeout=10000 --retries=3 *.js"
+    "test": "mocha --timeout=10000 --retries=3 *.js"
   }
 }


### PR DESCRIPTION
FORCE_COLOR also works for jest, so we can use this for
participate.whatwg.org as well:
https://github.com/whatwg/participate.whatwg.org/pull/113
