### PR TITLE
Sort review-drafts dir listings date-descending

### DIFF
--- a/debian/marquee/nginx/conf/whatwg.conf
+++ b/debian/marquee/nginx/conf/whatwg.conf
@@ -31,7 +31,7 @@ fancyindex on;
 fancyindex_exact_size off;
 fancyindex_css_href "https://resources.whatwg.org/nginx-fancyindex-whatwg.css";
 
-location /(commit-snapshots|review-drafts) {
+location ~ /(commit-snapshots|review-drafts) {
     fancyindex_default_sort date_desc;
 }
 


### PR DESCRIPTION
This change properly causes the review-drafts directory listings to be sorted by date in descending order, just as the commit-snapshots listings are.

Fixes https://github.com/whatwg/misc-server/issues/138

---

The previous fix didn’t work due to a syntax oversight.