### PR TITLE
Sort review-drafts dir listings name-descending

### DIFF
--- a/debian/marquee/nginx/conf/whatwg.conf
+++ b/debian/marquee/nginx/conf/whatwg.conf
@@ -31,8 +31,12 @@ fancyindex on;
 fancyindex_exact_size off;
 fancyindex_css_href "https://resources.whatwg.org/nginx-fancyindex-whatwg.css";
 
-location ~ /(commit-snapshots|review-drafts) {
+location /commit-snapshots {
     fancyindex_default_sort date_desc;
+}
+
+location /review-drafts {
+    fancyindex_default_sort name_desc;
 }
 
 include mime.types; # prevents adding types from clobbering all other defaults


### PR DESCRIPTION
This change causes the review-drafts directory listings to be sorted by name in descending order — rather than by date descending (as the commit-snapshots listings are).