### PR TITLE
Deploy blog.whatwg.org via DigitalOcean apps

### DIFF
--- a/digitalocean/README.md
+++ b/digitalocean/README.md
@@ -4,5 +4,5 @@ The configuration is deployed manually with these steps:
 
 1. Replace `__PRIVATE_CONFIG_JSON__` in `participate.yaml` with the actual JSON, as a base64-encoded string
 1. Run `doctl apps list` to get the ID of the apps.
-1. For each app in [`participate`, `build`]:
+1. For each app in [`participate`, `build`, `blog`]:
     1. Run `doctl apps update $ID --spec=$APP.yaml`

--- a/digitalocean/blog.yaml
+++ b/digitalocean/blog.yaml
@@ -10,26 +10,26 @@ services:
   envs:
   - key: WORDPRESS_DB_HOST
     scope: RUN_TIME
-    value: ${db-mysql-nyc3-38716.HOSTNAME}:${db-mysql-nyc3-38716.PORT}
+    value: ${whatwg-db.HOSTNAME}:${whatwg-db.PORT}
   - key: WORDPRESS_DB_NAME
     scope: RUN_TIME
-    value: ${db-mysql-nyc3-38716.DATABASE}
+    value: ${whatwg-db.DATABASE}
   - key: WORDPRESS_DB_USER
     scope: RUN_TIME
-    value: ${db-mysql-nyc3-38716.USERNAME}
+    value: ${whatwg-db.USERNAME}
   - key: WORDPRESS_DB_PASSWORD
     scope: RUN_TIME
-    value: ${db-mysql-nyc3-38716.PASSWORD}
+    value: ${whatwg-db.PASSWORD}
   - key: WORDPRESS_EXTRA_CONFIG
     scope: RUN_TIME
     value: |
       define('DB_CHARSET', 'utf8mb4');
   github:
-    branch: do-apps # TODO update
+    branch: main
     deploy_on_push: true
     repo: whatwg/blog.whatwg.org
   health_check:
-    http_path: /
+    http_path: /feed-autodiscovery
   http_port: 80
   instance_count: 1
   instance_size_slug: basic-xxs
@@ -37,10 +37,10 @@ services:
   routes:
   - path: /
 databases:
-- cluster_name: db-mysql-nyc3-38716
+- cluster_name: whatwg-db
   db_name: whatblogdb
   db_user: whatbloguser
   engine: MYSQL
-  name: db-mysql-nyc3-38716
+  name: whatwg-db
   production: true
   version: "8"

--- a/digitalocean/blog.yaml
+++ b/digitalocean/blog.yaml
@@ -1,0 +1,46 @@
+# https://www.digitalocean.com/docs/app-platform/references/app-specification-reference/
+domains:
+- domain: blog.whatwg.org
+  type: PRIMARY
+  zone: whatwg.org
+name: blog
+region: nyc
+services:
+- dockerfile_path: Dockerfile
+  envs:
+  - key: WORDPRESS_DB_HOST
+    scope: RUN_TIME
+    value: ${db-mysql-nyc3-38716.HOSTNAME}:${db-mysql-nyc3-38716.PORT}
+  - key: WORDPRESS_DB_NAME
+    scope: RUN_TIME
+    value: ${db-mysql-nyc3-38716.DATABASE}
+  - key: WORDPRESS_DB_USER
+    scope: RUN_TIME
+    value: ${db-mysql-nyc3-38716.USERNAME}
+  - key: WORDPRESS_DB_PASSWORD
+    scope: RUN_TIME
+    value: ${db-mysql-nyc3-38716.PASSWORD}
+  - key: WORDPRESS_EXTRA_CONFIG
+    scope: RUN_TIME
+    value: |
+      define('DB_CHARSET', 'utf8mb4');
+  github:
+    branch: do-apps # TODO update
+    deploy_on_push: true
+    repo: whatwg/blog.whatwg.org
+  health_check:
+    http_path: /
+  http_port: 80
+  instance_count: 1
+  instance_size_slug: basic-xxs
+  name: blog
+  routes:
+  - path: /
+databases:
+- cluster_name: db-mysql-nyc3-38716
+  db_name: whatblogdb
+  db_user: whatbloguser
+  engine: MYSQL
+  name: db-mysql-nyc3-38716
+  production: true
+  version: "8"

--- a/digitalocean/blog.yaml
+++ b/digitalocean/blog.yaml
@@ -32,7 +32,7 @@ services:
     http_path: /feed-autodiscovery
   http_port: 80
   instance_count: 1
-  instance_size_slug: basic-xxs
+  instance_size_slug: basic-xs
   name: blog
   routes:
   - path: /


### PR DESCRIPTION
This seems to work: https://blog-6tqz3.ondigitalocean.app/.

However it's a bit hard to test things because WordPress has a very strong notion of what its own URL is, which I believe is stored in the database. So every link on that staging site actually ends up going to the original https://blog.whatwg.org/. I can't access the admin panel either.

It looks like maybe we could get a better test by setting some extra config settings https://wordpress.org/support/article/changing-the-site-url/ so I'll probably try that tomorrow.