### PR TITLE
Replace // lines with # in whatwg-headers.conf

### DIFF
--- a/debian/marquee/nginx/conf/whatwg-headers.conf
+++ b/debian/marquee/nginx/conf/whatwg-headers.conf
@@ -1,6 +1,6 @@
-// These headers should be kept (mostly) in sync with
-// https://github.com/whatwg/participate.whatwg.org and
-// https://github.com/whatwg/blog.whatwg.org.
+# These headers should be kept (mostly) in sync with
+# https://github.com/whatwg/participate.whatwg.org and
+# https://github.com/whatwg/blog.whatwg.org.
 add_header Access-Control-Allow-Origin "*" always;
 add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
I don’t know why this didn’t cause any problems earlier, but since lines starting with `//` aren’t valid comments in nginx confing files, the lines we had starting with `//` were causing nginx to fail to parse the config file, and to fail to start.

So, this replaces those `//` with `#`.