### PR TITLE
Redirect HTML's multipage/web-sockets.html

### DIFF
--- a/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
@@ -23,6 +23,9 @@ server {
     location = /multipage/tabular-data.html {
         return 301 /multipage/tables.html;
     }
+    location = /multipage/web-sockets.html {
+        return 301 https://websockets.spec.whatwg.org/;
+    }
 
     # Intentionally deleted previously-generated filenames for /multipage/:
     location = /multipage/section-sql.html {


### PR DESCRIPTION
Part of https://github.com/whatwg/html/pull/7414. This *can* land beforehand though, I believe.