### PR TITLE
Redirect another HTML WebSockets URL found in the wild

### DIFF
--- a/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
+++ b/debian/marquee/nginx/sites/html.spec.whatwg.org.conf
@@ -26,6 +26,9 @@ server {
     location = /multipage/web-sockets.html {
         return 301 https://websockets.spec.whatwg.org/;
     }
+    location = /multipage/websockets {
+        return 301 https://websockets.spec.whatwg.org/;
+    }
     location = /multipage/window-object.html {
         return 301 /multipage/nav-history-apis.html;
     }

--- a/test/redirects.mjs
+++ b/test/redirects.mjs
@@ -84,6 +84,7 @@ const HTTPS_TESTS = [
   ['https://html.spec.whatwg.org/multipage/scripting-1.html', 301, 'https://html.spec.whatwg.org/multipage/scripting.html'],
   ['https://html.spec.whatwg.org/multipage/section-sql.html', 410],
   ['https://html.spec.whatwg.org/multipage/tabular-data.html', 301, 'https://html.spec.whatwg.org/multipage/tables.html'],
+  ['https://html.spec.whatwg.org/multipage/websockets/', 301, 'https://websockets.spec.whatwg.org/'],
   ['https://javascript.spec.whatwg.org/', 302, 'https://github.com/tc39/ecma262/labels/web%20reality', 'drop'],
   ['https://lists.whatwg.org/htdig.cgi', 301, 'https://lists.whatwg.org/pipermail/', 'keep'],
   ['https://lists.whatwg.org/listinfo.cgi', 301, 'https://lists.whatwg.org/'],


### PR DESCRIPTION
Not sure where this is from, but might as well handle it.

Closes https://github.com/whatwg/html/issues/9871.